### PR TITLE
Support primitive contract attachment

### DIFF
--- a/soft-contract/fake-contract.rkt
+++ b/soft-contract/fake-contract.rkt
@@ -8,6 +8,7 @@
                     parametric->/c
                     recursive-contract
                     define/contract
+                    contract
                     contract?)
          (except-in racket/set set/c)
          (for-syntax racket/base
@@ -37,7 +38,7 @@
          dynamic-struct-out
          dynamic-id-struct-out
          dynamic-define-opaque
-         define/contract dynamic-mon
+         define/contract contract dynamic-mon
          (rename-out [-define define])
          --> forall
          (rename-out [--> ⇒] [forall ∀]))
@@ -232,6 +233,13 @@
     [(_ x         c e    )
      (with-syntax ([rhs (with-syntax-source #'x #'(dynamic-mon 'x c e))])
        #'(define x rhs))]))
+
+(define-syntax contract
+  (syntax-parser
+    [(_ c e _ _)
+     (with-syntax-source #'e #'(dynamic-mon 'anonymous c e))]
+    [(_ c e _ _ (quote name:id) _)
+     (with-syntax-source #'e #'(dynamic-mon 'name c e))]))
 
 (define (dynamic-mon x c e) e)
 

--- a/soft-contract/parse/expand-keep-contracts.rkt
+++ b/soft-contract/parse/expand-keep-contracts.rkt
@@ -60,6 +60,7 @@
   (add! #'parameter/c #'f:parameter/c)
   (add! #'flat-contract #'f:flat-contract)
   (add! #'define/contract #'f:define/contract)
+  (add! #'contract #'f:contract)
   (add! #'contract? #'f:contract?)
   )
 

--- a/soft-contract/test/programs/safe/issues/primitive-attachment.rkt
+++ b/soft-contract/test/programs/safe/issues/primitive-attachment.rkt
@@ -1,0 +1,7 @@
+#lang racket
+
+((contract (-> string? string?)
+            (λ (x) (string-append x "!"))
+            #f
+            #f)
+  "hi")

--- a/soft-contract/test/programs/unsafe/issues/primitive-attachment.rkt
+++ b/soft-contract/test/programs/unsafe/issues/primitive-attachment.rkt
@@ -1,0 +1,7 @@
+#lang racket
+
+((contract (-> string? string?)
+            (λ (x) (string-append x "!"))
+            'pos
+            'neg)
+  5)


### PR DESCRIPTION
I believe this should be enough to support the primitive `contract` form. 

cc @Temurson